### PR TITLE
Update pedrovsrr.md and outdated links

### DIFF
--- a/src/misc/pedrovsrr.md
+++ b/src/misc/pedrovsrr.md
@@ -4,9 +4,9 @@
 based on Wolfpack Machina's powerplay autonomous movement.
 It uses a custom algorithm to follow trajectories with speed as a top priority.
 
-Docs: <https://pedro-pathing-projects.github.io/documentation/>
+Docs: <https://pedropathing.com/>
 
-Quickstart: <https://github.com/AnyiLin/Pedro-Pathing-Quickstart>
+Quickstart: <https://github.com/Pedro-Pathing/Pedro-Pathing-Quickstart>
 
 **Pros of Pedro:**
 


### PR DESCRIPTION
Updated PedroPathing Documentation link in pedropathing vs roadrunner page under misc. to a non-dead link to the newest documentation website. 
Also updated working link to pedropathing quickstart to latest repository. 