### PR TITLE
Fix typo in forward velocity auto tuner

### DIFF
--- a/automatic/forwardvelocity.md
+++ b/automatic/forwardvelocity.md
@@ -9,7 +9,7 @@ The **Forward Velocity Tuner** determines the velocity of your robot when moving
 ## Setup and Instructions
 
 1. Open the `ForwardVelocityTuner.java` OpMode.
-2. Ensure your robot has enough space to drive **40 inches** forward. You can adjust this distance in the FTC Dashboard under the `ForwardVelocityTuner` dropdown, but larger distances yield better results.
+2. Ensure your robot has enough space to drive **48 inches** forward. You can adjust this distance in the FTC Dashboard under the `ForwardVelocityTuner` dropdown, but larger distances yield better results.
 3. Run the OpMode.
 
 
@@ -26,6 +26,6 @@ The **Forward Velocity Tuner** determines the velocity of your robot when moving
 1. Open the `FConstants` class and navigate to the `static{}` block.
 2. Then, on a new line, add `FollowerConstants.xMovement = [OUTPUT]`, with `[OUTPUT]` being the velocity output from the tuner.
 
-Note: In Step 2, you only need to make a new line if you are not using the quickstart, otherwise, you can just modify the line that already does this.  
+Note: In Step 2, you only need to make a new line if you are not using the quickstart, otherwise, you can just modify the line that already does this.
 
 #### Congratulations, you’ve completed the forward velocity tuning!


### PR DESCRIPTION
It currently says 40 inches ensure that the robot has 40 inches of space, it should changed to be 48.