### PR TITLE
updated opmode imports in docs

### DIFF
--- a/pedro/examples/auto.md
+++ b/pedro/examples/auto.md
@@ -5,7 +5,7 @@ It serves as a **template** for an Into the Deep Bucket Side autonomous, and it 
 It can be viewed [here](https://github.com/Pedro-Pathing/Quickstart/blob/master/TeamCode/src/main/java/pedroPathing/examples/ExampleBucketAuto.java) on Github
 
 ```java
-package pedroPathing.examples;
+package org.firstinspires.ftc.teamcode.pedroPathing.examples;
 
 import com.pedropathing.follower.Follower;
 import com.pedropathing.localization.Pose;
@@ -19,8 +19,8 @@ import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import  com.qualcomm.robotcore.eventloop.opmode.OpMode;
 
-import pedroPathing.constants.FConstants;
-import pedroPathing.constants.LConstants;
+import org.firstinspires.ftc.teamcode.pedroPathing.constants.FConstants;
+import org.firstinspires.ftc.teamcode.pedroPathing.constants.LConstants;
 
 /**
  * This is an example auto that showcases movement and control of two servos autonomously.

--- a/pedro/examples/buildauto.md
+++ b/pedro/examples/buildauto.md
@@ -8,7 +8,7 @@ This guide provides a comprehensive overview of how to create an autonomous rout
 Include the required package and imports for PedroPathing functionalities:
 
 ```java
-package pedroPathing.examples;
+package org.firstinspires.ftc.teamcode.pedroPathing.examples;
 
 import com.pedropathing.follower.Follower;
 import com.pedropathing.localization.Pose;
@@ -21,8 +21,8 @@ import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 
-import pedroPathing.constants.FConstants;
-import pedroPathing.constants.LConstants;
+import org.firstinspires.ftc.teamcode.pedroPathing.constants.FConstants;
+import org.firstinspires.ftc.teamcode.pedroPathing.constants.LConstants;
 ```
 
 

--- a/pedro/examples/teleop.md
+++ b/pedro/examples/teleop.md
@@ -5,7 +5,7 @@ It serves as a **template** for a robot-centric teleop.
 It can also be viewed [here](https://github.com/Pedro-Pathing/Quickstart/blob/master/TeamCode/src/main/java/pedroPathing/examples/ExampleRobotCentricTeleop.java) on Github
 
 ```java
-package pedroPathing.examples;
+package org.firstinspires.ftc.teamcode.pedroPathing.examples;
 
 import com.pedropathing.follower.Follower;
 import com.pedropathing.localization.Pose;
@@ -13,8 +13,8 @@ import com.pedropathing.util.Constants;
 import  com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
-import pedroPathing.constants.FConstants;
-import pedroPathing.constants.LConstants;
+import org.firstinspires.ftc.teamcode.pedroPathing.constants.FConstants;
+import org.firstinspires.ftc.teamcode.pedroPathing.constants.LConstants;
 
 /**
  * This is an example teleop that showcases movement and robot-centric driving.


### PR DESCRIPTION
I may have missed something, but this should reflect the 1.0.9 quickstart packages and imports